### PR TITLE
First pass on SushiJoin

### DIFF
--- a/src/crop.sol
+++ b/src/crop.sol
@@ -1,6 +1,10 @@
 pragma solidity 0.6.12;
 
-import "dss-interfaces/dss/VatAbstract.sol";
+interface VatLike {
+    function urns(bytes32, address) external view returns (uint256, uint256);
+    function gem(bytes32, address) external view returns (uint256);
+    function slip(bytes32, address, int256) external;
+}
 
 interface ERC20 {
     function balanceOf(address owner) external view returns (uint256);
@@ -14,7 +18,7 @@ interface ERC20 {
 // receives tokens and shares them among holders
 contract CropJoin {
 
-    VatAbstract public immutable vat;    // cdp engine
+    VatLike     public immutable vat;    // cdp engine
     bytes32     public immutable ilk;    // collateral type
     ERC20       public immutable gem;    // collateral token
     uint256     public immutable dec;    // gem decimals
@@ -34,7 +38,7 @@ contract CropJoin {
     event Tack(address indexed src, address indexed dst, uint256 wad);
 
     constructor(address vat_, bytes32 ilk_, address gem_, address bonus_) public {
-        vat = VatAbstract(vat_);
+        vat = VatLike(vat_);
         ilk = ilk_;
         gem = ERC20(gem_);
         uint256 dec_ = ERC20(gem_).decimals();
@@ -133,7 +137,7 @@ contract CropJoin {
         uint256 val = wmul(wmul(wad, nps()), 10 ** dec);
 
         require(gem.transfer(usr, val));
-        vat.slip(ilk, usr, -int(wad));
+        vat.slip(ilk, usr, -int256(wad));
 
         total = sub(total, wad);
         stake[usr] = sub(stake[usr], wad);

--- a/src/crop.sol
+++ b/src/crop.sol
@@ -160,5 +160,4 @@ contract CropJoin {
 
         emit Tack(src, dst, wad);
     }
-
 }

--- a/src/sushi.sol
+++ b/src/sushi.sol
@@ -16,30 +16,36 @@ interface MasterChefLike {
 contract SushiJoin is CropJoin {
 
     // --- Auth ---
-    mapping (address => uint) public wards;
+    mapping (address => uint256) public wards;
     function rely(address usr) external auth {
         wards[usr] = 1;
-
         emit Rely(usr);
     }
     function deny(address usr) external auth {
         wards[usr] = 0;
-
         emit Deny(usr);
     }
     modifier auth {
-        require(wards[msg.sender] == 1, "GemJoin/not-authorized");
+        require(wards[msg.sender] == 1, "SushiJoin/not-authorized");
         _;
     }
 
     MasterChefLike  immutable public masterchef;
     uint256         immutable public pid;
-    bool            public live = true;
+    bool                      public live;
 
     // --- Events ---
     event Rely(address indexed usr);
     event Deny(address indexed usr);
 
+    /**
+        @param vat_         MCD_VAT DSS core accounting module
+        @param ilk_         Collateral type
+        @param gem_         The collateral LP token address
+        @param bonus_       The SUSHI token contract address.
+        @param masterchef_  The SushiSwap MCV1 contract address.
+        @param pid_         The index of the sushi pool.
+    */
     constructor(address vat_, bytes32 ilk_, address gem_, address bonus_, address masterchef_, uint256 pid_)
         public
         CropJoin(vat_, ilk_, gem_, bonus_)
@@ -54,6 +60,7 @@ contract SushiJoin is CropJoin {
 
         ERC20(gem_).approve(masterchef_, uint256(-1));
         wards[msg.sender] = 1;
+        live = true;
     }
     function nav() public override returns (uint256) {
         return total;

--- a/src/sushi.sol
+++ b/src/sushi.sol
@@ -62,9 +62,11 @@ contract SushiJoin is CropJoin {
         wards[msg.sender] = 1;
         live = true;
     }
+
     function nav() public override returns (uint256) {
         return total;
     }
+
     function crop() internal override returns (uint256) {
         if (live) {
             // withdraw of 0 will give us only the rewards
@@ -72,17 +74,20 @@ contract SushiJoin is CropJoin {
         }
         return super.crop();
     }
+
     function join(uint256 val) public override {
         require(live, "SushiJoin/not-live");
         super.join(val);
         masterchef.deposit(pid, val);
     }
+
     function exit(uint256 val) public override {
         if (live) {
             masterchef.withdraw(pid, val);
         }
         super.exit(val);
     }
+
     function flee() public override {
         if (live) {
             uint256 val = vat.gem(ilk, msg.sender);
@@ -90,6 +95,7 @@ contract SushiJoin is CropJoin {
         }
         super.flee();
     }
+
     function cage() external auth {
         masterchef.emergencyWithdraw(pid);
         live = false;

--- a/src/test/sushi.t.sol
+++ b/src/test/sushi.t.sol
@@ -27,12 +27,12 @@ contract Usr {
         adapter = join_;
         pair = pair_;
 
-        vat = adapter.vat();
+        vat = VatAbstract(address(adapter.vat()));
         masterchef = adapter.masterchef();
         wbtc = ERC20(pair.token0());
         weth = ERC20(pair.token1());
         pid = adapter.pid();
-        
+
         pair.approve(address(adapter), uint(-1));
         pair.approve(address(masterchef), uint(-1));
     }
@@ -305,7 +305,7 @@ contract SushiTest is TestBase {
         join.cage();
 
         // Should not take the rewards, only the actual LP token
-        assertEq(unclaimedAdapterRewards(), 0); 
+        assertEq(unclaimedAdapterRewards(), 0);
         assertEq(sushi.balanceOf(address(join)), prewards);
         assertEq(pair.balanceOf(address(join)), join.total());
     }
@@ -361,7 +361,7 @@ contract SushiTest is TestBase {
         hevm.roll(block.number + wait2);
 
         doExit(user1, amount1 / 4);
-        
+
         hevm.roll(block.number + wait3);
 
         doExit(user2, amount2 / 3);
@@ -547,5 +547,5 @@ contract SushiTest is TestBase {
             }
         }
     }
-    
+
 }


### PR DESCRIPTION
Quick first pass on the SushiJoin. Since it inherits everything from CropJoin we'll need to review that as well and it looks like it needs a battery of tests on it's own. 

There are some public functions exposed on the CropJoin that aren't tested but that will be available on the SushiJoin.

Added some docs, the distinct vat interface to avoid the import in the core contract and fixed some datatypes. 